### PR TITLE
Update the TwigView::generateHelperList() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "WyriHaximus\\CakePHP\\Tests\\TwigView\\": "tests/"
+            "WyriHaximus\\CakePHP\\Tests\\TwigView\\": "tests/",
+            "App\\": "tests/test_app/"
         }
     }
 }

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -164,7 +164,9 @@ class TwigView extends View
     protected function generateHelperList()
     {
         $registry = $this->helpers();
-        $helpers = $registry->normalizeArray($this->helpers);
+        
+        $helpersList = array_merge($this->helpers, $registry->loaded());
+        $helpers = $registry->normalizeArray($helpersList);
         foreach ($helpers as $properties) {
             list(, $class) = pluginSplit($properties['class']);
             $this->helperList[$class] = $this->{$class};

--- a/tests/View/TwigViewTest.php
+++ b/tests/View/TwigViewTest.php
@@ -140,10 +140,10 @@ class TwigViewTest extends TestCase
 			]
 		);
 
-        $view = new TwigView(Phake::mock('Cake\Network\Request'), Phake::mock('Cake\Network\Response'), Phake::mock('Cake\Event\EventManager'));
-        $view->TestHelper = 'foo:bar';
-        $view->helpers = $helpersArray;
-        $view->loadHelper('TestSecond');
+		$view = new TwigView(Phake::mock('Cake\Network\Request'), Phake::mock('Cake\Network\Response'), Phake::mock('Cake\Event\EventManager'));
+		$view->TestHelper = 'foo:bar';
+		$view->helpers = $helpersArray;
+		$view->loadHelper('TestSecond');
 		$view->TestSecond = 'bar:foo';
 
 		self::getMethod('generateHelperList')->invoke($view);

--- a/tests/View/TwigViewTest.php
+++ b/tests/View/TwigViewTest.php
@@ -143,11 +143,14 @@ class TwigViewTest extends TestCase
         $view = new TwigView(Phake::mock('Cake\Network\Request'), Phake::mock('Cake\Network\Response'), Phake::mock('Cake\Event\EventManager'));
         $view->TestHelper = 'foo:bar';
         $view->helpers = $helpersArray;
+        $view->loadHelper('TestSecond');
+		$view->TestSecond = 'bar:foo';
 
 		self::getMethod('generateHelperList')->invoke($view);
 		$this->assertSame(
 			[
 				'TestHelper' => 'foo:bar',
+				'TestSecond' => 'bar:foo',
 			],
 			self::getProperty('helperList')->getValue($view)
 		);

--- a/tests/test_app/View/Helper/TestSecondHelper.php
+++ b/tests/test_app/View/Helper/TestSecondHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of TwigView.
+ *
+ ** (c) 2014 Cees-Jan Kiewiet
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace App\View\Helper;
+
+use Cake\View\Helper;
+
+class TestSecondHelper extends Helper
+{
+}


### PR DESCRIPTION
Since Helpers can also be loaded using the `View::loadHelper()` method, the Helpers list is in fact composed with the helpers in the "helpers" property of the View object and with the helpers loaded in the registry using the `loadHelper()` method.

I added a test case to cover the new helper list generation behavior.

Refs #29 