### PR TITLE
Sync the TwigView::_getElementFileName method signature with View::_g…

### DIFF
--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -268,16 +268,17 @@ class TwigView extends View
 
     /**
      * @param string $name
+     * @param bool $pluginCheck
      * @return string
      * @throws \Exception
      */
     // @codingStandardsIgnoreStart
-    protected function _getElementFileName($name)
+    protected function _getElementFileName($name, $pluginCheck = true)
     {
         // @codingStandardsIgnoreEnd
         foreach ($this->extensions as $extension) {
             $this->_ext = $extension;
-            $result = parent::_getElementFileName($name);
+            $result = parent::_getElementFileName($name, $pluginCheck);
             if ($result !== false) {
                 return $result;
             }


### PR DESCRIPTION
Some recent changes made to a method of `View` that the plugin overloads and released on 3.3.4 throws a PHP error because methods signatures don't match.

This is only for 3.3.4 and forward.
The changes [can be found here](https://github.com/cakephp/cakephp/commit/5ad7d95b24f90c49f68b32355c75c2f6432cb79e)