### PR TITLE
Checking for $options !== null

### DIFF
--- a/src/Lib/Twig/Node/Cell.php
+++ b/src/Lib/Twig/Node/Cell.php
@@ -90,7 +90,7 @@ class Cell extends \Twig_Node implements \Twig_NodeOutputInterface
             $compiler->subcompile($data);
         }
         $options = $this->getNode('options');
-        if ($data !== null) {
+        if ($options !== null) {
             $compiler->raw(',');
             $compiler->subcompile($options);
         }


### PR DESCRIPTION
Makes more sense to check $options for null in line 93 instead of data.