### PR TITLE
Check if the DebugKit plugin is loaded before binding an event linked to it

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,13 +1,14 @@
 <?php
 
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Event\EventManager;
 use WyriHaximus\TwigView\Event;
 
 EventManager::instance()->on(new Event\ExtensionsListener());
 EventManager::instance()->on(new Event\TokenParsersListener());
 
-if (Configure::read('debug')) {
+if (Configure::read('debug') && Plugin::loaded('DebugKit')) {
     Configure::write('DebugKit.panels', array_merge(
         (array)Configure::read('DebugKit.panels'),
         [


### PR DESCRIPTION
Deploying with `debug` to `false` and a `composer update --no-dev` (so without DebugKit) leads to a fatal error where the `DebugKit\DebugTimer` class can not be found.

A check to see if DebugKit is loaded before binding an event that will need to use some of its classes should be made.