### PR TITLE
Return '' on echo $this; for TwigView

### DIFF
--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -296,4 +296,14 @@ class TwigView extends View
     {
         return $this->twig;
     }
+
+    /**
+     * Return empty string when View instance is cast to string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
This will fix `{{ _view.assign('foo', 'bar') }}` and similar uses (that are a bit wrong and should be `{% _view.assign('foo', 'bar') %}`;
Latter will hopefully be possible/fixed in 5.x through some new twig tags. However templates then will need to be updated at some point before this hack can be removed again.