### PR TITLE
Correct fallback order so all extensions are check before falling back to the next path on the list

### DIFF
--- a/tests/Lib/RelativeScannerTest.php
+++ b/tests/Lib/RelativeScannerTest.php
@@ -59,6 +59,9 @@ class RelativeScannerTest extends TestCase
     {
         $this->assertEquals([
             'APP' => [
+                'Blog/index.twig',
+                'Element/element.twig',
+                'Layout/layout.twig',
                 'exception.twig',
                 'layout.twig',
                 'syntaxerror.twig',

--- a/tests/Lib/ScannerTest.php
+++ b/tests/Lib/ScannerTest.php
@@ -59,6 +59,9 @@ class ScannerTest extends TestCase
     {
         $this->assertSame([
             'APP' => [
+                PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS . 'Blog' . DS . 'index.twig',
+                PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS . 'Element' . DS . 'element.twig',
+                PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS . 'Layout' . DS . 'layout.twig',
                 PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS . 'exception.twig',
                 PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS . 'layout.twig',
                 PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS . 'syntaxerror.twig',

--- a/tests/Lib/TreeScannerTest.php
+++ b/tests/Lib/TreeScannerTest.php
@@ -59,9 +59,18 @@ class TreeScannerTest extends TestCase
     {
         $this->assertEquals([
             'APP' => [
-                'exception.twig',
-                'layout.twig',
-                'syntaxerror.twig',
+                3 => 'exception.twig',
+                4 => 'layout.twig',
+                5 => 'syntaxerror.twig',
+                'Blog' => [
+                    'index.twig',
+                ],
+                'Element' => [
+                    'element.twig',
+                ],
+                'Layout' => [
+                    'layout.twig',
+                ],
             ],
             'TestTwigView' => [
                 3 => 'twig.twig',

--- a/tests/View/TwigViewTest.php
+++ b/tests/View/TwigViewTest.php
@@ -10,6 +10,7 @@
  */
 use App\View\AppView;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use WyriHaximus\TwigView\Event\ConstructEvent;
@@ -217,4 +218,71 @@ class TwigViewTest extends TestCase
 		$view->render('syntaxerror');
 	}
 
+    public function testGetViewFileNameFallbackChecksCtpFirstBeforeTryingOtherPaths()
+    {
+        Configure::write('App.paths.templates', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS);
+        Configure::write('App.paths.plugins', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS);
+        Plugin::load('Modern');
+
+        $view = new AppView();
+        $view->layout = false;
+        $view->theme = 'Modern';
+        $this->assertSame('index.ctp', $view->render('Blog/index'));
+	}
+
+    public function testGetLayoutFileNameFallbackChecksCtpFirstBeforeTryingOtherPaths()
+    {
+        Configure::write('App.paths.templates', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS);
+        Configure::write('App.paths.plugins', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS);
+        Plugin::load('Modern');
+
+        $view = new AppView();
+        $view->layout = 'layout';
+        $view->theme = 'Modern';
+        $this->assertSame('layout.ctp', $view->render('Blog/index'));
+	}
+
+    public function testGetElementFileNameFallbackChecksCtpFirstBeforeTryingOtherPaths()
+    {
+        Configure::write('App.paths.templates', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS);
+        Configure::write('App.paths.plugins', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS);
+        Plugin::load('Modern');
+
+        $view = new AppView();
+        $view->layout = false;
+        $view->theme = 'Modern';
+        $this->assertSame('element.ctp', $view->element('element'));
+	}
+    public function testGetViewFileNameFallbackChecksCtpFirstBeforeTryingOtherPathsFallingBackToOtherPaths()
+    {
+        Configure::write('App.paths.templates', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS);
+        Configure::write('App.paths.plugins', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS);
+        Plugin::load('Modern');
+
+        $view = new AppView();
+        $view->layout = false;
+        $this->assertSame('index.twig', $view->render('Blog/index'));
+	}
+
+    public function testGetLayoutFileNameFallbackChecksCtpFirstBeforeTryingOtherPathsFallingBackToOtherPaths()
+    {
+        Configure::write('App.paths.templates', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS);
+        Configure::write('App.paths.plugins', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS);
+        Plugin::load('Modern');
+
+        $view = new AppView();
+        $view->layout = 'layout';
+        $this->assertSame('layout.twig', $view->render('Blog/index'));
+	}
+
+    public function testGetElementFileNameFallbackChecksCtpFirstBeforeTryingOtherPathsFallingBackToOtherPaths()
+    {
+        Configure::write('App.paths.templates', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Template' . DS);
+        Configure::write('App.paths.plugins', PLUGIN_REPO_ROOT . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS);
+        Plugin::load('Modern');
+
+        $view = new AppView();
+        $view->layout = false;
+        $this->assertSame('element.twig', $view->element('element'));
+	}
 }

--- a/tests/test_app/Plugin/Modern/src/Template/Blog/index.ctp
+++ b/tests/test_app/Plugin/Modern/src/Template/Blog/index.ctp
@@ -1,0 +1,1 @@
+index.ctp

--- a/tests/test_app/Plugin/Modern/src/Template/Element/element.ctp
+++ b/tests/test_app/Plugin/Modern/src/Template/Element/element.ctp
@@ -1,0 +1,1 @@
+element.ctp

--- a/tests/test_app/Plugin/Modern/src/Template/Layout/layout.ctp
+++ b/tests/test_app/Plugin/Modern/src/Template/Layout/layout.ctp
@@ -1,0 +1,1 @@
+layout.ctp

--- a/tests/test_app/Template/Blog/index.twig
+++ b/tests/test_app/Template/Blog/index.twig
@@ -1,0 +1,1 @@
+index.twig

--- a/tests/test_app/Template/Element/element.twig
+++ b/tests/test_app/Template/Element/element.twig
@@ -1,0 +1,1 @@
+element.twig

--- a/tests/test_app/Template/Layout/layout.twig
+++ b/tests/test_app/Template/Layout/layout.twig
@@ -1,0 +1,1 @@
+layout.twig


### PR DESCRIPTION
As reported by @ADmad the current behavior causes issue for `cakephp/bake`.