### PR TITLE
Update TwigTemplateTask for upcoming bake changes.

### DIFF
--- a/src/Shell/Task/TwigTemplateTask.php
+++ b/src/Shell/Task/TwigTemplateTask.php
@@ -30,23 +30,27 @@ class TwigTemplateTask extends TemplateTask
     /**
      * Assembles and writes bakes the twig view file.
      *
-     * @param string $action Action to bake.
+     * @param string $template Template to generate content with.
      * @param string $content Content to write.
+     * @param string $outputFile The destination action name. If null, will fallback to $template.
      * @return string Generated file content.
      */
-    public function bake($action, $content = '')
+    public function bake($template, $content = '', $outputFile = null)
     {
+        if ($outputFile === null) {
+            $outputFile = $template;
+        }
         if ($content === true) {
-            $content = $this->getContent($action);
+            $content = $this->getContent($template);
         }
         if (empty($content)) {
-            $this->err("<warning>No generated content for '{$action}.ctp', not generating template.</warning>");
+            $this->err("<warning>No generated content for '{$template}.ctp', not generating template.</warning>");
 
             return false;
         }
-        $this->out("\n" . sprintf('Baking `%s` view twig template file...', $action), 1, Shell::QUIET);
+        $this->out("\n" . sprintf('Baking `%s` view twig template file...', $outputFile), 1, Shell::QUIET);
         $path = $this->getPath();
-        $filename = $path . Inflector::underscore($action) . '.twig';
+        $filename = $path . Inflector::underscore($outputFile) . '.twig';
         $this->createFile($filename, $content);
 
         return $content;

--- a/tests/Shell/Task/TwigTemplateTaskTest.php
+++ b/tests/Shell/Task/TwigTemplateTaskTest.php
@@ -160,4 +160,21 @@ class TemplateTaskTest extends TestCase
         $this->assertSameAsFile(__FUNCTION__ . '.twig', $result);
     }
 
+    /**
+     * test baking an index with output file
+     *
+     * @return void
+     */
+    public function testBakeIndexWithOutputFile()
+    {
+        $this->Task->modelName = __NAMESPACE__ . '\\TemplateTask\\AuthorsTable';
+        $this->Task->controllerName = 'Authors';
+        $this->Task->controllerClass = __NAMESPACE__ . '\\TemplateTask\\AuthorsController';
+
+        $this->Task->expects($this->at(0))->method('createFile')
+            ->with(
+                $this->_normalizePath(APP . 'Template/Authors/listing.twig')
+            );
+        $this->Task->bake('index', true, 'listing');
+    }
 }


### PR DESCRIPTION
To solve cakephp/bake#395 I had to add an additional parameter to the public `bake` method. While this is OK from a backwards compatibility point of view, it does trigger a strict error in this plugin. I've also fixed the issue present in cakephp/bake#395 that was also found here.