### PR TITLE
Fix deprecation warning with CakePHP 3.7.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -8,7 +8,7 @@ use WyriHaximus\TwigView\Event;
 EventManager::instance()->on(new Event\ExtensionsListener());
 EventManager::instance()->on(new Event\TokenParsersListener());
 
-if (Configure::read('debug') && Plugin::loaded('DebugKit')) {
+if (Configure::read('debug') && Plugin::getCollection()->has('DebugKit')) {
     Configure::write('DebugKit.panels', array_merge(
         (array)Configure::read('DebugKit.panels'),
         [


### PR DESCRIPTION
I missed one in my previous PR :disappointed: 