### PR TITLE
Deprecation for realz

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
           "phpunit"
         ]
     },
+    "abandoned": "cakephp/twig-view",
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
What is the opinion about this?
Right now v4 is also already supported on cakephp/twig-view
And v5 only there

So it seems we could hard-deprecate this one and have people do a community follow up if really needed, e.g. for v3?